### PR TITLE
Fix: Buffer type issue in PDF generate route

### DIFF
--- a/app/api/pdf/generate/route.ts
+++ b/app/api/pdf/generate/route.ts
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
     console.log(`[PDF Generator] Successfully generated ${filename} in ${totalTime}ms`);
 
     // Return PDF as response
-    return new NextResponse(result.buffer, {
+    return new NextResponse(new Uint8Array(result.buffer), {
       status: 200,
       headers: {
         'Content-Type': 'application/pdf',


### PR DESCRIPTION
## Summary
Fixes TypeScript type error in the PDF generation API route by properly converting the buffer to a `Uint8Array` before passing it to `NextResponse`.

## Problem
The current implementation passes `result.buffer` directly to `NextResponse`, which can cause TypeScript type errors. The `NextResponse` constructor expects specific types for the body parameter, and raw buffers may not be compatible with all TypeScript configurations.

## Solution
Changed line 103 from:
```typescript
return new NextResponse(result.buffer, {
```

To:
```typescript
return new NextResponse(new Uint8Array(result.buffer), {
```

This uses the recommended `Uint8Array` approach, which is the standard way to handle binary data in modern JavaScript/TypeScript and is explicitly supported by the `NextResponse` API.

## Benefits
- ✅ Resolves TypeScript type errors
- ✅ Uses the recommended approach for binary data handling
- ✅ Maintains full compatibility with existing functionality
- ✅ No changes to the API behavior or response format

## Testing
- The fix has been applied to `app/api/pdf/generate/route.ts`
- No changes to the PDF generation logic
- Response headers and content remain unchanged

## Files Changed
- `app/api/pdf/generate/route.ts` - Line 103