### PR TITLE
Fix TypeScript buffer issue in PDF generation route

### DIFF
--- a/app/api/pdf/generate/route.ts
+++ b/app/api/pdf/generate/route.ts
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
     console.log(`[PDF Generator] Successfully generated ${filename} in ${totalTime}ms`);
 
     // Return PDF as response
-    return new NextResponse(result.buffer, {
+    return new NextResponse(new Uint8Array(result.buffer), {
       status: 200,
       headers: {
         'Content-Type': 'application/pdf',


### PR DESCRIPTION
Resolves TypeScript error in app/api/pdf/generate/route.ts by converting Buffer to Uint8Array in the NextResponse, similar to the fix already applied in the BEO generate-pdf route.

## Changes
- Modified line 103 in `app/api/pdf/generate/route.ts`
- Changed `return new NextResponse(result.buffer, {` to `return new NextResponse(new Uint8Array(result.buffer), {`

## Problem
TypeScript was throwing an error when passing a Buffer directly to NextResponse, as it expects a more specific typed array.

## Solution
Convert the Buffer to Uint8Array before passing it to NextResponse. This is the recommended approach and aligns with the existing fix in other PDF generation routes in the codebase.

## Testing
- Verify TypeScript compilation succeeds without errors
- Ensure PDF generation continues to work as expected