### PR TITLE
Fix: Add guestCount to KitchenBEO interface to resolve TypeScript error

### DIFF
--- a/components/templates/KitchenBEO.tsx
+++ b/components/templates/KitchenBEO.tsx
@@ -10,6 +10,7 @@ export interface KitchenBEOData {
     eventTime: string;
     clientName: string;
     venue: string;
+    guestCount: number;
     logoUrl?: string;
   };
   guests: {
@@ -236,6 +237,7 @@ const KitchenBEOHeader: React.FC<KitchenBEOData['header']> = ({
   eventTime,
   clientName,
   venue,
+  guestCount,
   logoUrl,
 }) => {
   return (
@@ -286,6 +288,12 @@ const KitchenBEOHeader: React.FC<KitchenBEOData['header']> = ({
               Venue
             </span>
             <span className="font-serif text-xl">{venue}</span>
+          </div>
+          <div>
+            <span className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
+              Guest Count
+            </span>
+            <span className="font-serif text-xl">{guestCount}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🐛 Problem

Vercel deployment was failing due to a TypeScript compilation error in `components/templates/sample-data.ts` at line 20:

```typescript
header: {
  // ...
  guestCount: 150,  // ❌ TypeScript Error: Property 'guestCount' does not exist on type
}
```

The `KitchenBEOData` interface in `components/templates/KitchenBEO.tsx` was missing the `guestCount` field in the `header` object, causing type mismatch when sample data included this field.

## ✅ Solution

Added `guestCount: number` field to the `header` interface in `KitchenBEOData` (line 12 in `KitchenBEO.tsx`).

## 📝 Changes Made

### File: `components/templates/KitchenBEO.tsx`

1. **Updated Interface** (Line 12):
   ```typescript
   export interface KitchenBEOData {
     header: {
       beoNumber: string;
       eventName: string;
       eventDate: string;
       eventTime: string;
       clientName: string;
       venue: string;
       guestCount: number;  // ← ADDED
       logoUrl?: string;
     };
     // ...
   }
   ```

2. **Updated Component** (Line 240):
   - Added `guestCount` parameter to `KitchenBEOHeader` component destructuring

3. **Updated UI Display** (Lines 297-303):
   - Added Guest Count display section in the header alongside Date, Time, and Venue
   ```typescript
   <div>
     <span className="text-xs uppercase tracking-wider text-muted-foreground block mb-1">
       Guest Count
     </span>
     <span className="font-serif text-xl">{guestCount}</span>
   </div>
   ```

## ✅ Verification

- ✅ TypeScript error in `components/templates/sample-data.ts` (line 20) is resolved
- ✅ Interface now matches sample data structure
- ✅ HTML template generator (`lib/html-templates/kitchen-beo-template.ts`) can properly access `data.header.guestCount`
- ✅ Guest count is now displayed in the Kitchen BEO header section

## 🎯 Impact

- **Fixes:** Vercel deployment failure due to TypeScript compilation error
- **Improves:** Type safety across Kitchen BEO template components
- **Adds:** Visual display of guest count in Kitchen BEO header

## 🔍 Related Files

Files that use `guestCount` and are now properly typed:
- ✅ `components/templates/KitchenBEO.tsx` (interface definition & component)
- ✅ `components/templates/sample-data.ts` (sample data usage)
- ✅ `lib/html-templates/kitchen-beo-template.ts` (HTML template generator)

## 📋 Testing Checklist

- [x] TypeScript compiles without errors
- [x] Interface properly typed with `guestCount: number`
- [x] Component displays guest count in header
- [x] Sample data matches interface structure
- [x] No breaking changes to existing functionality

---

**Ready to merge** - This fix resolves the deployment blocker and maintains type consistency across the Kitchen BEO template system.